### PR TITLE
Fix default characters type to string

### DIFF
--- a/src/baffle.js
+++ b/src/baffle.js
@@ -7,7 +7,7 @@ import {
 import Obfuscator from './obfuscator';
 
 const defaults = {
-    characters: 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz~!@#$%^&*()-+=[]{}|;:,./<>?'.split(''),
+    characters: 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz~!@#$%^&*()-+=[]{}|;:,./<>?',
     speed: 50
 };
 


### PR DESCRIPTION
The documentation states that the current default characters are a
string but it's actually an array