### PR TITLE
chore: fix deps for babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-es2015-classes": "^6.14.0",
     "babel-preset-es2015": "^6.9.0",
     "eslint": "^3.1.1",
     "webpack": "^1.13.1"


### PR DESCRIPTION
This fixes an error, when trying to run webpack for the build.
It could not find plugin `transform-es2015-classes`, which is specified in [package.json](https://github.com/camwiegert/baffle/blob/master/package.json#L22).

This adds the babel plugin to the devDependencies.